### PR TITLE
Bump ESP32 builder

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ jobs:
             }
 
     container:
-      image: connectedhomeip/chip-build-esp32:0.5.77
+      image: connectedhomeip/chip-build-esp32:0.5.99
 
     outputs:
       git-hash: ${{ steps.git-version.outputs.hash }}


### PR DESCRIPTION
Use the `connectedhomeip/chip-build-esp32` container image currently used in the v1.0 branch.