### PR TITLE
Replace set-output commands with GITHUB_OUTPUT environment vars

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Get firmware git hash
         run: |
           ghash=$(git -C connectedhomeip rev-parse --short HEAD)
-          echo "::set-output name=hash::${ghash}"
+          echo "hash=${ghash}" >> $GITHUB_OUTPUT
         id: git-version
 
       - name: Build


### PR DESCRIPTION
The set-output commands via stdout are deprecated. Use the GITHUB_OUTPUT environment variable as suggested by GitHub.