### PR TITLE
Fix Github Actions running out of space

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,7 +79,6 @@ jobs:
         with:
           repository: project-chip/connectedhomeip
           ref: ${{ matrix.firmware.chip_ref }}
-          submodules: true
           path: connectedhomeip
 
       # Fixup for Matter v1.1 (see https://github.com/project-chip/connectedhomeip/pull/28507/files)


### PR DESCRIPTION
Testing these examples with esp-idf 5.1 images and the builds always run out of space. Dropping submodules from CHIP checkout fixes this, these are handled later by:

`scripts/checkout_submodules.py --shallow --platform esp32`

NB: chip 1.1 builds currently fail with unrelated gevent/gdbgui issues, likely fixed in the v1.1 branch but havent updated refs here.